### PR TITLE
Add commit -S command to git_commands

### DIFF
--- a/git_commands.md
+++ b/git_commands.md
@@ -127,6 +127,11 @@ $ git fetch [<options>] [<repository> [<refspec>…​]]
 $ git commit -m "[message]"
 ```
 
+### Фиксация изменений с подписью
+```sh
+$ git commit -S -m "[message]"
+```
+
 #### Просмотр истории коммитов
 ```sh
 $ git log [<options>] [<revision range>] [[--] <path>...]


### PR DESCRIPTION
Added commit command with -S parameter, which creates a signed commit
https://help.github.com/articles/signing-commits/